### PR TITLE
Corrige l’utilisation et la documentation de \codedest

### DIFF
--- a/facture.dtx
+++ b/facture.dtx
@@ -349,8 +349,9 @@
         }{}
         \ifdef{\@codedest}{%
             \libelle{{\codeclient}} \@codedest        
-        }{}
-        \ifdef{\@datelimite}{\\\AdvanceDate[\@datelimite]\libelle{{\datelimitetxt}} \today}{}
+                \\
+          }{}
+        \ifdef{\@datelimite}{\AdvanceDate[\@datelimite]\libelle{{\datelimitetxt}} \today}{}
     };
     
     \end{tikzpicture}

--- a/facture.dtx
+++ b/facture.dtx
@@ -94,7 +94,7 @@
 %
 %L'adresse de livraison se définie via la commande \DescribeMacro{\dest}\cmd{\dest}\marg{adresse}, l'adresse de facturation via \DescribeMacro{\fact}\marg{adresse}. Encore une fois, les différentes lignes de l'adresse doivent être séparées par \verb|\\|.
 %
-% Il est possible d'affecter un code au client, via la commande \DescribeMacro{\codeclient}\cmd{\codeclient}\marg{code}.
+% Il est possible d'affecter un code au client, via la commande \DescribeMacro{\codedest}\cmd{\codedest}\marg{code}.
 %\subsection{Affichage des méta-données}
 %Toutes ces méta-données, à l'exception du taux de TVA et du pied de page sont affichées dans une zolie présentation avec la commande. \DescribeMacro{\entete}\cmd{\entete}.
 %\section{Insertion de texte}

--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ all:facture.pdf exemple.pdf exemplesansTVA.pdf exemplesansremise.pdf
 	rm -f ../facture.zip
 	rm -rf facture
 	mkdir facture
-	ln *pdf *ins *dtx  *tex README makefile facture
+	ln *pdf *ins *dtx  *tex README.md makefile facture
 	zip -r ../facture.zip facture
 
 


### PR DESCRIPTION
Ces deux commits apportent les corrections suivantes :

- La documentation actuelle déclare dans la section 1.5 Information sur le destinataire « \codeclient Il est possible d’affecter un code au client, via la commande \codeclient{⟨code⟩}. » Je pense qu’il s’agit d’une erreur et que l’on parle ici de la commande `\codedest`. En effet la commande `\codeclient` est utilisée pour définir le texte utilisé en préfixe de ce même code client (par défaut "Code client :")
- La documentation (et le code) semble admettre que \codedest est sensé être optionnel. Malheureusement, sans \codedest la compilation échoue avec l’erreur ci-après. Je propose un correctif en déplaçant convenablement les marqueurs de fin de ligne `\\`.

```
! LaTeX Error: There's no line here to end.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...

l.67 \entete
```